### PR TITLE
Fix apache-httpcomponents-client-4-api (4.5.3-2.0) incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.625.2</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
 
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>7</java.level>
@@ -83,69 +83,35 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.parent.groupId}</groupId>
-      <artifactId>matrix-project</artifactId>
-      <version>1.3</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.enigmabridge</groupId>
       <artifactId>hibernate4-sqlite-dialect</artifactId>
       <version>0.1.2</version>
     </dependency>
 
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>jira</artifactId>
+      <version>2.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>structs</artifactId>
       <version>1.5</version>
     </dependency>
-
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>1.9</version>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.6</version>
     </dependency>
-
     <dependency>
-      <groupId>com.atlassian.jira</groupId>
-      <artifactId>jira-rest-java-client-api</artifactId>
-      <version>2.0.0-m19</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.atlassian.jira</groupId>
-      <artifactId>jira-rest-java-client-core</artifactId>
-      <version>2.0.0-m19</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>14.0-rc1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.jettison</groupId>
-      <artifactId>jettison</artifactId>
-      <version>1.0.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.6.4</version>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.4</version>
+      <groupId>${project.parent.groupId}.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.8</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
git-client (2.7.0) requires apache-httpcomponents-client-4-api (4.5.3-2.0) and jira-rest-java-client is not compatible with apache-httpcomponents-client-4-api